### PR TITLE
Add Atom feed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,12 +8,6 @@ base_url = "https://scrabsha.github.io"
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
 
-# Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_code = true
-# highlight_theme = "charcoal"
-highlight_theme = "zenburn"
-
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
 
@@ -26,3 +20,10 @@ author = "Sasha Pourcelot"
 
 copyright = "Written by Sasha Pourcelot, delivered under the [CC BY SA v4.0](https://creativecommons.org/licenses/by-sa/4.0/) license. Black Lives Matter."
 subtitle = "Some thoughts about my computer science journey"
+
+[markdown]
+# Whether to do syntax highlighting
+# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
+highlight_code = true
+# highlight_theme = "charcoal"
+highlight_theme = "zenburn"

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,8 @@ compile_sass = true
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
 
+generate_feed = true
+
 # Theme
 theme = "zola-pickles"
 


### PR DESCRIPTION
Hi, I'm interested to hear about your `syn` experience.

Here's some config to generate `atom.xml` for the blog. I also updated zola sections to build with 0.13 without warning:

```
`highlight_code` has been moved to a [markdown] section. Top level `highlight_code` and `highlight_theme` will stop working in 0.14.
```

However, I can't make sense of this zola 0.14.1 error:

```
-> Creating 1 pages (0 orphan), 0 sections, and processing 0 images
Error: Failed to render page 'B:/code/scrabsha.github.io/src/content/draft-0.md'
Reason: Failed to render 'page.html' (error happened in 'index.html').
Reason: Variable `config.default_language` not found in context while rendering 'page.html'
```

I hope you can build with 0.13!

Update: I refreshed zola-pickles submodule for the fix `config.default_language` -> `lang` now.

PS btw people can subscribe to the repo's GH feed, feel free to close this.