### PR TITLE
Don't hardcode Id for root

### DIFF
--- a/content/abcr-issue-0.md
+++ b/content/abcr-issue-0.md
@@ -1,6 +1,7 @@
 +++
 title = "A better cargo-readme - Issue 0: Humble Beginning"
 date = 2021-12-06
+updated = 2021-12-08
 +++
 
 # Introduction

--- a/content/abcr-issue-0.md
+++ b/content/abcr-issue-0.md
@@ -205,17 +205,16 @@ The JSON document follows a specific structure defined in the `rustdoc_json_type
 
 ## Extracting the crate-level documentation
 
-After a few minutes of diving in the data structures, we can see that all the items that are reachable from the crate are located in the [`index`] field. This field is a JSON dictionary whose keys are compiler-generated [`Id`]s and values are metadata of the reachable items. Additionally, there is a [`root`]
-field, which tells us which key in the index map will give us the documentation for the crate's root module.
+After a few minutes of diving in the data structures, we can see that all the items that are reachable from the crate are located in the [`index`] field. This field is a JSON dictionary whose keys are compiler-generated [`Id`]s and values are metadata of the reachable items. Additionally, there is a [`root`] field, which tells us which key in the index map will give us the documentation for the crate's root module.
 
 Let's try to write a command which extracts the crate-level documentation using `jq`:
 
-[`id`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/struct.Id.html
+[`Id`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/struct.Id.html
 [`root`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/struct.Crate.html#structfield.root
 [`index`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/struct.Crate.html#structfield.index
 
 ```
-$ cat target/doc/abcr_step0.json | jq '.root as $root | {docs: .index[$root].docs}'
+$ cat target/doc/abcr_step0.json | jq '{docs: .index[.root].docs}'
 {
   "docs": "# My crate\n\nThe [`Cow`] says moo 🐮\n\n```TOML\n[dependencies]\nabcr_step0 = \"0.1.0\"\n```\n\nHere's some crate-level documentation"
 }
@@ -231,7 +230,7 @@ We did it! We managed to extract the crate documentation from the rustdoc-genera
 [`links`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/struct.Item.html#structfield.links
 
 ```
-$ cat target/doc/abcr_step0.json | jq '.root as $root | { docs: .index[$root].docs, links: .index[$root].links }'
+$ cat target/doc/abcr_step0.json | jq '{ docs: .index[.root].docs, links: .index[.root].links }'
 {
   "docs": "# My crate\n\n```TOML\n[dependencies]\nabcr_step0 = \"0.1.0\"\n```\n\nHere's some crate-level documentation\n\nHere's a link to [`Cow`].",
   "links": {

--- a/content/abcr-issue-0.md
+++ b/content/abcr-issue-0.md
@@ -268,4 +268,8 @@ This issue was reviewed by volunteers who gave me a lot of feedback. They are, i
   - [Natsukoh](https://twitter.com/natsukoow),
   - [Yozhgoor 🦀](https://twitter.com/yozhgoor).
 
+Initial release of the blogpost used a hardcoded `id` to retrieve the crate-level documentation. [@aDotInTheVoid] suggested to use the `root` field instead. Thanks!
+
+[@aDotInTheVoid]: https://github.com/aDotInTheVoid
+
 If you're interested in reviewing the next articles or implementation, don't hesitate to message me on Twitter. I gladly welcome any kind of constructive feedback.


### PR DESCRIPTION
The Json ID's are opaque, and may be changed at any point (In fact, I;m: To quote the [rfc](https://rust-lang.github.io/rfcs/2963-rustdoc-json.html#id):

> They happen to be the compiler internal DefId for that item, but in the JSON blob they should be treated as opaque as they aren't guaranteed to be stable across compiler invocations.

In fact, Its possible rustdoc should mangle `Id`s, so they dont look human readable, because they arn't indended to convey any information themself.

Also: Thanks for writing this post, and I'm super glad to see people finding uses for rustdoc-json. Please file issues if you run into anything or can think of improvements to the json format.
